### PR TITLE
Fetch datasets removed from vayla from traficom

### DIFF
--- a/import/fetch-csv-from-vayla.sh
+++ b/import/fetch-csv-from-vayla.sh
@@ -4,17 +4,20 @@ set -e
 # APIs:
 # - https://julkinen.vayla.fi/inspirepalvelu/rajoitettu/wfs?request=GetCapabilities
 # - https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=GetCapabilities
+# - https://julkinen.traficom.fi/inspirepalvelu/rajoitettu/wms?request=getcapabilities
+# - https://julkinen.traficom.fi/inspirepalvelu/avoin/wms?request=getcapabilities
 # Data documentation: https://vayla.fi/documents/20473/38174/Merikartta-aineistojen_tietosis%C3%A4ll%C3%B6n_kuvaus.pdf/78afa9e5-8f7c-4430-b798-f9848c79123f
+# Overview documentation: https://www.paikkatietohakemisto.fi/geonetwork/srv/fin/catalog.search#/metadata/1d1c8600-76bf-4e1f-bd09-b5c154ca30dc
 
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd $PARENT_PATH
 cd ..
 
-curl "https://julkinen.vayla.fi/inspirepalvelu/rajoitettu/wfs?request=GetFeature&outputFormat=csv&typeNames=rajoitettu:syvyyskayra_v&srsName=urn:ogc:def:crs:EPSG::4326" -o data/syvyyskayra.csv
+curl "https://julkinen.traficom.fi/inspirepalvelu/rajoitettu/wfs?request=GetFeature&outputFormat=csv&typeNames=rajoitettu:DepthContour_L&srsName=urn:ogc:def:crs:EPSG::4326" -o data/syvyyskayra.csv
 
-curl "https://julkinen.vayla.fi/inspirepalvelu/rajoitettu/wfs?request=GetFeature&outputFormat=csv&typeNames=rajoitettu:syvyysalue_a&srsName=urn:ogc:def:crs:EPSG::4326" -o data/syvyysalue.csv
+curl "https://julkinen.traficom.fi/inspirepalvelu/rajoitettu/wfs?request=GetFeature&outputFormat=csv&typeNames=rajoitettu:DepthArea_A&srsName=urn:ogc:def:crs:EPSG::4326" -o data/syvyysalue.csv
 
-curl "https://julkinen.vayla.fi/inspirepalvelu/rajoitettu/wfs?request=GetFeature&outputFormat=csv&typeNames=rajoitettu:syvyyspiste_p&srsName=urn:ogc:def:crs:EPSG::4326" -o data/syvyyspiste.csv
+curl "https://julkinen.traficom.fi/inspirepalvelu/rajoitettu/wfs?request=GetFeature&outputFormat=csv&typeNames=rajoitettu:Sounding_P&srsName=urn:ogc:def:crs:EPSG::4326" -o data/syvyyspiste.csv
 
 curl "https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=GetFeature&outputFormat=csv&typeNames=avoin:vaylaalueet&srsName=urn:ogc:def:crs:EPSG::4326" -o data/vaylaalueet.csv
 
@@ -28,7 +31,7 @@ curl "https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=GetFeature&outp
 
 curl "https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=GetFeature&outputFormat=csv&typeNames=avoin:navigointilinjat&srsName=urn:ogc:def:crs:EPSG::4326" -o data/navigointilinjat.csv
 
-curl "https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=GetFeature&outputFormat=csv&typeNames=avoin:rantarakenteet_v&srsName=urn:ogc:def:crs:EPSG::4326" -o data/rantarakenteet.csv
+curl "https://julkinen.traficom.fi/inspirepalvelu/avoin/wfs?request=GetFeature&outputFormat=csv&typeNames=avoin:ShorelineConstruction_L&srsName=urn:ogc:def:crs:EPSG::4326" -o data/rantarakenteet.csv
 
 curl "https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=GetFeature&outputFormat=csv&typeNames=avoin:tutkamajakat&srsName=urn:ogc:def:crs:EPSG::4326" -o data/tutkamajakat.csv
 

--- a/import/prepare-geojson-data.sh
+++ b/import/prepare-geojson-data.sh
@@ -6,8 +6,8 @@ cd $PARENT_PATH
 cd ..
 
 ## Syvyysalue: Split "blue" and "white" water into own files, merge polygons and chop features up for Mapbox/PostGIS import
-node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -filter invert '["3","6","10"].includes(MAXDEPTH)' -drop fields=MAXDEPTH -split-on-grid 200,500 -dissolve2 gap-fill-area=1m2 TYPEDEPR -clean gap-fill-area=1m2 -merge-layers -each 'WATER="white"' -o 'data/syvyysalueet-dissolved-white.geojson'
-node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -filter '["3","6","10"].includes(MAXDEPTH)' -drop fields=MAXDEPTH -split-on-grid 100,100 -dissolve TYPEDEPR -clean gap-fill-area=1m2 -merge-layers -each 'WATER="blue"' -explode -o 'data/syvyysalueet-dissolved-blue.geojson'
+node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -filter invert '["3","6","10"].includes(DRVAL2)' -drop fields=DRVAL2 -split-on-grid 200,500 -dissolve2 gap-fill-area=1m2 DRVAL1 -clean gap-fill-area=1m2 -merge-layers -each 'WATER="white"' -o 'data/syvyysalueet-dissolved-white.geojson'
+node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -filter '["3","6","10"].includes(DRVAL2)' -drop fields=DRVAL2 -split-on-grid 100,100 -dissolve DRVAL1 -clean gap-fill-area=1m2 -merge-layers -each 'WATER="blue"' -explode -o 'data/syvyysalueet-dissolved-blue.geojson'
 
 ## Syvyysalue: create flattened and heavily simplified file
 node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -drop fields=* -dissolve2 gap-fill-area=100m2 -explode -simplify 1% -o geojson-type=FeatureCollection data/syvyysalueet-simplified.geojson
@@ -32,4 +32,4 @@ node_modules/mapshaper/bin/mapshaper -i data/maastokuvionreuna.geojson -filter i
 
 
 
-node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -filter '["3","6","10"].includes(MAXDEPTH)' -drop fields=MAXDEPTH -each 'WATER="blue"' -o 'data/syvyysalueet-dissolved-blue.geojson'
+node_modules/mapshaper/bin/mapshaper -i data/syvyysalue.geojson -filter '["3","6","10"].includes(DRVAL2)' -drop fields=DRVAL2 -each 'WATER="blue"' -o 'data/syvyysalueet-dissolved-blue.geojson'

--- a/server/layers.js
+++ b/server/layers.js
@@ -19,7 +19,7 @@ const layers = [
     layer: 'syvyysalueet',
     table: 'syvyysalueet',
     extent: 4096,
-    fields: ['typedepr', 'water'],
+    fields: ['drval1', 'water'],
     buffer: 256,
     minZoom: 6
   },
@@ -105,7 +105,7 @@ const layers = [
     layer: 'syvyyspiste',
     table: 'syvyyspiste',
     extent: 1024,
-    fields: ['depth::float', 'typesound::int'],
+    fields: ['depth::float', 'quasou::int'],
     buffer: 30,
     minZoom: 13
   },


### PR DESCRIPTION
Traficom took ownership of hosting some of the datasets previously
hosted by Vayla. More details can be found on the github issue:
https://github.com/vokkim/finnish-nautical-chart-vectors/issues/13